### PR TITLE
Convert multiple 'type' entries to valid 'oneOf' entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "chalk": "^4.1.2",
     "js-yaml": "^4.1.0",
     "lutils": "^2.4.0",
-    "typescript-json-schema": "^0.53.1",
+    "typescript-json-schema": "^0.54.0",
     "uuid": "^8.3.2"
   },
   "prettier": {

--- a/src/ServerlessOpenApiDocumentation.ts
+++ b/src/ServerlessOpenApiDocumentation.ts
@@ -160,8 +160,22 @@ export class ServerlessOpenApiDocumentation {
 
     const { definition } = generator;
 
-    // Output the OpenAPI document to the correct format
+    // Convert multiple 'type' entries to valid 'oneOf' entries, see 'Mixed Types' at
+    // https://swagger.io/docs/specification/data-models/data-types/
+    const convertTypeArrayToOneOf = (schema) => {
+      if (Array.isArray(schema.type)) {
+        schema.oneOf = schema.type.map((type) => ({ type }));
+        delete schema.type;
+      }
+      Object.keys(schema).forEach((key) => {
+        if (schema[key] && typeof schema[key] === 'object') {
+          convertTypeArrayToOneOf(schema[key]);
+        }
+      });
+    };
+    convertTypeArrayToOneOf(definition.components);
 
+    // Output the OpenAPI document to the correct format
     let output;
     switch (config.format.toLowerCase()) {
       case 'json':


### PR DESCRIPTION
When a schema property has multiple types, the current yml (and equivalent json output) is

```yml
type:
  - string
  - integer
```

which is incorrect against the spec. This PR corrects this output to valid

```yml
oneOf:
  - type: string
  - type: integer
```

see 'Mixed Types' section at https://swagger.io/docs/specification/data-models/data-types.

I appreciate this is a bit of a 'hacky' fix, but I find this package very helpful in a lot of projects (in fact your fork was from my fork of this repo in the first place!). Hopefully looking for a quick fix.

This PR also updates the dependency `typescript-json-schema` to `v0.54.0`.

Thanks!